### PR TITLE
Remove gpg-plugin

### DIFF
--- a/norconex-committer-elasticsearch-rest/pom.xml
+++ b/norconex-committer-elasticsearch-rest/pom.xml
@@ -242,20 +242,6 @@
             </plugin>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-gpg-plugin</artifactId>
-              <version>1.6</version>
-              <executions>
-                <execution>
-                  <id>sign-artifacts</id>
-                  <phase>verify</phase>
-                  <goals>
-                    <goal>sign</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-antrun-plugin</artifactId>
               <version>1.7</version>
               <executions>


### PR DESCRIPTION
- Users can install it locally, or publish to their local artifactory, without having your gpg keypair.
- Alternate is for you to publish it to central so users don't have to build it locally.