### PR TITLE
Change group to com.norconex.collectors

### DIFF
--- a/norconex-committer-elasticsearch-rest/pom.xml
+++ b/norconex-committer-elasticsearch-rest/pom.xml
@@ -15,9 +15,10 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
   http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.norconex.committers</groupId>
+	<groupId>com.norconex.collectors</groupId>
 	<artifactId>norconex-committer-elasticsearch-rest</artifactId>
 	<version>0.0.1</version>
+  <packaging>jar</packaging>
 	<name>Norconex Committer Elasticsearch REST</name>
 
 


### PR DESCRIPTION
Noticed that on a search on Maven central, the group is "com.norconex.collectors" even for the collectors, and I am suggesting you change it for consistency.

Another thing could be to ask Paul whether it might be appropriate to put it in another group, perhaps "com.norconex.collectors.contrib" to distinguish it from the supported work.

Anyway, "com.norconex.committers" is neither consistent nor semantically clear, but I still very much want to use this code ;)
